### PR TITLE
Optimize exchange pipeline performance

### DIFF
--- a/backend/src/core/orders.py
+++ b/backend/src/core/orders.py
@@ -43,7 +43,5 @@ class OrderService:
             updated_at=datetime.utcnow(),
         )
         self.session.add(db_order)
-        await self.session.commit()
-        await self.session.refresh(db_order)
+        await self.session.flush()
         return db_order
-

--- a/backend/src/exchange/manager.py
+++ b/backend/src/exchange/manager.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Iterable
 
-from sqlalchemy import select
+from sqlalchemy import inspect, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.db.models import Order as OrderModel
@@ -17,63 +18,120 @@ from src.exchange.engine import MatchingEngine, SimpleCancel, SimpleOrder, Simpl
 @dataclass
 class OrderBookState:
     engine: MatchingEngine
+    loaded: bool = False
+    simple_orders: dict[str, SimpleOrder] = field(default_factory=dict)
+    order_models: dict[str, OrderModel] = field(default_factory=dict)
 
 
 class ExchangeManager:
     def __init__(self) -> None:
         self._books: dict[str, OrderBookState] = {}
 
-    def _get_engine(self, symbol_code: str) -> MatchingEngine:
+    def _get_or_create_state(self, symbol_code: str) -> OrderBookState:
         state = self._books.get(symbol_code)
         if state is None:
             state = OrderBookState(engine=MatchingEngine())
             self._books[symbol_code] = state
-        return state.engine
+        return state
+
+    async def ensure_symbol_loaded(
+        self,
+        session: AsyncSession,
+        symbol_code: str,
+        *,
+        exclude_order_ids: set[str] | None = None,
+    ) -> OrderBookState:
+        state = self._get_or_create_state(symbol_code)
+        if not state.loaded:
+            await self.load_open_orders(
+                session, symbol_code=symbol_code, exclude_order_ids=exclude_order_ids
+            )
+        elif exclude_order_ids:
+            for order_id in exclude_order_ids:
+                state.engine.remove_order(order_id)
+                state.simple_orders.pop(order_id, None)
+                state.order_models.pop(order_id, None)
+        return state
 
     def get_orderbook_levels(
         self, symbol_code: str, depth: int = 50
     ) -> tuple[list[tuple[float, int]], list[tuple[float, int]]]:
-        engine = self._get_engine(symbol_code)
-        return engine.get_orderbook_levels(depth)
+        state = self._books.get(symbol_code)
+        if state is None or not state.loaded:
+            return [], []
+        return state.engine.get_orderbook_levels(depth)
 
-    async def load_open_orders(self, session: AsyncSession) -> None:
-        # Rebuild in-memory books from the database to avoid duplicates
-        # and stale orders persisting across requests.
-        for state in self._books.values():
-            state.engine.reset()
-
-        rows = (
-            await session.execute(
-                select(
-                    OrderModel.id,
-                    SymbolModel.symbol,
-                    OrderModel.side,
-                    OrderModel.team_id,
-                    OrderModel.order_type,
-                    OrderModel.quantity,
-                    OrderModel.filled_quantity,
-                    OrderModel.price,
-                    OrderModel.status,
+    async def load_open_orders(
+        self,
+        session: AsyncSession,
+        symbol_code: str | None = None,
+        *,
+        exclude_order_ids: set[str] | None = None,
+    ) -> None:
+        if symbol_code is not None:
+            state = self._get_or_create_state(symbol_code)
+            orders = (
+                await session.execute(
+                    select(OrderModel)
+                    .join(SymbolModel, SymbolModel.id == OrderModel.symbol_id)
+                    .where(
+                        SymbolModel.symbol == symbol_code,
+                        OrderModel.status.in_(["pending", "partial"]),
+                    )
+                    .order_by(OrderModel.created_at, OrderModel.id)
                 )
-                .join(SymbolModel, SymbolModel.id == OrderModel.symbol_id)
-                .where(OrderModel.status.in_(["pending", "partial"]))
-            )
-        ).all()
-        for r in rows:
-            remaining = r.quantity - r.filled_quantity
+            ).scalars().all()
+            self._populate_state_from_orders(state, orders, exclude_order_ids)
+            return
+
+        result = await session.execute(
+            select(OrderModel, SymbolModel.symbol)
+            .join(SymbolModel, SymbolModel.id == OrderModel.symbol_id)
+            .where(OrderModel.status.in_(["pending", "partial"]))
+            .order_by(SymbolModel.symbol, OrderModel.created_at, OrderModel.id)
+        )
+        rows = result.all()
+        grouped: dict[str, list[OrderModel]] = {}
+        for order_model, sym_code in rows:
+            grouped.setdefault(sym_code, []).append(order_model)
+
+        symbols_to_refresh = set(self._books.keys()) | set(grouped.keys())
+        for sym in symbols_to_refresh:
+            state = self._get_or_create_state(sym)
+            orders = grouped.get(sym, [])
+            self._populate_state_from_orders(state, orders, exclude_order_ids)
+
+    def _populate_state_from_orders(
+        self,
+        state: OrderBookState,
+        orders: Iterable[OrderModel],
+        exclude_order_ids: set[str] | None = None,
+    ) -> None:
+        state.engine.reset()
+        state.simple_orders.clear()
+        state.order_models.clear()
+        for order_model in orders:
+            if exclude_order_ids and str(order_model.id) in exclude_order_ids:
+                continue
+            remaining = order_model.quantity - order_model.filled_quantity
             if remaining <= 0:
                 continue
-            # Do not load market orders into the book; they should not rest
-            if r.order_type == "market" or r.price is None:
+            if order_model.order_type == "market" or order_model.price is None:
                 continue
-            order = SimpleOrder(
-                order_id=str(r.id),
-                side=r.side,
-                quantity=remaining,
-                price=float(r.price) if r.price is not None else None,
-                team_id=str(r.team_id),
-            )
-            self._get_engine(r.symbol).add_order(order)
+            simple = self._simple_from_model(order_model, remaining)
+            state.simple_orders[simple.order_id] = simple
+            state.order_models[simple.order_id] = order_model
+            state.engine.add_resting_order(simple)
+        state.loaded = True
+
+    def _simple_from_model(self, order: OrderModel, remaining: int) -> SimpleOrder:
+        return SimpleOrder(
+            order_id=str(order.id),
+            side=order.side,
+            quantity=remaining,
+            price=float(order.price) if order.price is not None else None,
+            team_id=str(order.team_id),
+        )
 
     async def place_and_match(
         self,
@@ -82,136 +140,151 @@ class ExchangeManager:
         db_order: OrderModel,
         symbol_code: str,
     ) -> list[TradeModel]:
-        # Rebuild the book for this symbol excluding the incoming order,
-        # then run matching and apply results to DB.
-        engine = self._get_engine(symbol_code)
-        engine.reset()
+        new_order_id = str(db_order.id)
+        state = await self.ensure_symbol_loaded(
+            session, symbol_code, exclude_order_ids={new_order_id}
+        )
 
-        # Load all open, non-market orders for this symbol except the incoming one
-        rows = (
-            await session.execute(
-                select(
-                    OrderModel.id,
-                    OrderModel.side,
-                    OrderModel.team_id,
-                    OrderModel.quantity,
-                    OrderModel.filled_quantity,
-                    OrderModel.price,
-                    OrderModel.order_type,
-                )
-                .join(SymbolModel, SymbolModel.id == OrderModel.symbol_id)
-                .where(
-                    SymbolModel.symbol == symbol_code,
-                    OrderModel.status.in_(["pending", "partial"]),
-                    OrderModel.id != db_order.id,
-                )
-            )
-        ).all()
-        for r in rows:
-            if r.order_type == "market" or r.price is None:
-                continue
-            remaining = r.quantity - r.filled_quantity
-            if remaining <= 0:
-                continue
-            engine.add_order(
-                SimpleOrder(
-                    order_id=str(r.id),
-                    side=r.side,
-                    quantity=remaining,
-                    price=float(r.price),
-                    team_id=str(r.team_id),
-                )
-            )
         remaining_qty = db_order.quantity - db_order.filled_quantity
         new_order = SimpleOrder(
-            order_id=str(db_order.id),
+            order_id=new_order_id,
             side=db_order.side,
             quantity=remaining_qty,
             price=float(db_order.price) if db_order.price is not None else None,
             team_id=str(db_order.team_id),
         )
-        simple_trades: list[SimpleTrade]
-        simple_cancels: list[SimpleCancel]
-        simple_trades, simple_cancels = engine.add_order(new_order)
+        state.order_models[new_order_id] = db_order
+
+        simple_trades, simple_cancels = state.engine.add_order(new_order)
+
+        # Only track the new order as resting if it is a limit order with remaining qty
+        if new_order.price is not None and new_order.quantity > 0:
+            state.simple_orders[new_order_id] = new_order
+        else:
+            state.simple_orders.pop(new_order_id, None)
+
         trades: list[TradeModel] = []
+        impacted_orders: set[str] = {new_order_id}
+        position_cache: dict[tuple[uuid.UUID, uuid.UUID], PositionModel] = {}
+
         for t in simple_trades:
-            buyer_id = uuid.UUID(t.buyer_order_id)
-            seller_id = uuid.UUID(t.seller_order_id)
-            # Fetch orders to get team and symbol context
-            buyer = await session.get(OrderModel, buyer_id)
-            seller = await session.get(OrderModel, seller_id)
-            if not buyer or not seller:
+            buyer_model = await self._get_order_model(session, state, t.buyer_order_id)
+            seller_model = await self._get_order_model(session, state, t.seller_order_id)
+            if not buyer_model or not seller_model:
                 continue
-            # Create trade row
+
             trade = TradeModel(
-                buyer_order_id=buyer.id,
-                seller_order_id=seller.id,
-                symbol_id=buyer.symbol_id,
+                buyer_order_id=buyer_model.id,
+                seller_order_id=seller_model.id,
+                symbol_id=buyer_model.symbol_id,
                 quantity=t.quantity,
                 price=t.price,
                 executed_at=datetime.utcnow(),
             )
             session.add(trade)
             trades.append(trade)
-            # Update orders filled quantities
-            buyer.filled_quantity += t.quantity
-            seller.filled_quantity += t.quantity
-            buyer.status = "filled" if buyer.filled_quantity >= buyer.quantity else "partial"
-            seller.status = "filled" if seller.filled_quantity >= seller.quantity else "partial"
-            buyer.updated_at = datetime.utcnow()
-            seller.updated_at = datetime.utcnow()
-            session.add(buyer)
-            session.add(seller)
-            # Update positions
+
+            self._apply_fill_to_order(buyer_model, t.quantity)
+            self._apply_fill_to_order(seller_model, t.quantity)
+            impacted_orders.update({t.buyer_order_id, t.seller_order_id})
+
             await self._apply_trade_to_position(
                 session,
-                team_id=buyer.team_id,
-                symbol_id=buyer.symbol_id,
+                team_id=buyer_model.team_id,
+                symbol_id=buyer_model.symbol_id,
                 side="buy",
                 qty=t.quantity,
                 price=t.price,
+                cache=position_cache,
             )
             await self._apply_trade_to_position(
                 session,
-                team_id=seller.team_id,
-                symbol_id=seller.symbol_id,
+                team_id=seller_model.team_id,
+                symbol_id=seller_model.symbol_id,
                 side="sell",
                 qty=t.quantity,
                 price=t.price,
+                cache=position_cache,
             )
 
-        # Apply cancellations (self-trade prevention) to resting orders
-        for c in simple_cancels:
-            oid = uuid.UUID(c.order_id)
-            o = await session.get(OrderModel, oid)
-            if not o:
+        for cancel in simple_cancels:
+            cancel_model = await self._get_order_model(session, state, cancel.order_id)
+            if not cancel_model:
                 continue
-            # Use filled_quantity to reduce remaining open size; no trade is recorded
-            o.filled_quantity += c.quantity
-            if o.filled_quantity >= o.quantity:
-                o.status = "cancelled"
+            cancel_model.filled_quantity += cancel.quantity
+            if cancel_model.filled_quantity >= cancel_model.quantity:
+                cancel_model.status = "cancelled"
             else:
-                o.status = "partial"
-            o.updated_at = datetime.utcnow()
-            session.add(o)
+                cancel_model.status = "partial"
+            cancel_model.updated_at = datetime.utcnow()
+            impacted_orders.add(cancel.order_id)
 
-        # Update the just-placed order status to reflect matches done
-        # For market orders, cancel any unfilled remainder (do not rest)
-        if db_order.order_type == "market":
-            # Refresh db_order to ensure latest filled_quantity from any trades above
-            await session.flush()
-            await session.refresh(db_order)
-            if db_order.filled_quantity >= db_order.quantity:
-                db_order.status = "filled"
-            else:
-                # Leave filled_quantity as-is; mark as cancelled to indicate done
-                db_order.status = "cancelled"
-                db_order.updated_at = datetime.utcnow()
-                session.add(db_order)
+        self._cleanup_orders(state, impacted_orders)
+        self._update_new_order_status(db_order)
 
-        await session.flush()
-        await session.refresh(db_order)
         return trades
+
+    async def _get_order_model(
+        self,
+        session: AsyncSession,
+        state: OrderBookState,
+        order_id: str,
+    ) -> OrderModel | None:
+        model = state.order_models.get(order_id)
+        try:
+            oid: uuid.UUID | str = uuid.UUID(order_id)
+        except ValueError:
+            oid = order_id
+        if model is not None:
+            bound_session = inspect(model).session
+            if bound_session is session.sync_session:
+                return model
+        model = await session.get(OrderModel, oid)
+        if model:
+            state.order_models[order_id] = model
+        return model
+
+    def _apply_fill_to_order(self, order: OrderModel, qty: int) -> None:
+        order.filled_quantity += qty
+        if order.filled_quantity >= order.quantity:
+            order.status = "filled"
+        else:
+            order.status = "partial"
+        order.updated_at = datetime.utcnow()
+
+    def _cleanup_orders(self, state: OrderBookState, order_ids: Iterable[str]) -> None:
+        for order_id in order_ids:
+            simple = state.simple_orders.get(order_id)
+            if simple is not None and simple.quantity <= 0:
+                state.engine.remove_order(order_id)
+                state.simple_orders.pop(order_id, None)
+            model = state.order_models.get(order_id)
+            if model and model.status in {"filled", "cancelled"}:
+                state.simple_orders.pop(order_id, None)
+                state.order_models.pop(order_id, None)
+
+    def _update_new_order_status(self, order: OrderModel) -> None:
+        if order.order_type == "market":
+            if order.filled_quantity >= order.quantity:
+                order.status = "filled"
+            else:
+                order.status = "cancelled"
+        else:
+            if order.filled_quantity >= order.quantity:
+                order.status = "filled"
+            elif order.filled_quantity > 0:
+                order.status = "partial"
+            else:
+                order.status = "pending"
+        order.updated_at = datetime.utcnow()
+
+    def remove_from_book(self, symbol_code: str, order_id: str) -> None:
+        state = self._books.get(symbol_code)
+        if not state or not state.loaded:
+            return
+        state.engine.remove_order(order_id)
+        state.simple_orders.pop(order_id, None)
+        state.order_models.pop(order_id, None)
 
     async def _apply_trade_to_position(
         self,
@@ -222,32 +295,37 @@ class ExchangeManager:
         side: str,
         qty: int,
         price: float,
+        cache: dict[tuple[uuid.UUID, uuid.UUID], PositionModel] | None = None,
     ) -> None:
-        pos = await session.get(PositionModel, {"team_id": team_id, "symbol_id": symbol_id})
-        if pos is None:
-            pos = PositionModel(
-                team_id=team_id,
-                symbol_id=symbol_id,
-                quantity=0,
-                average_price=None,
-                realized_pnl=0,
-            )
-            session.add(pos)
-            await session.flush()
+        key = (team_id, symbol_id)
+        if cache is not None and key in cache:
+            pos = cache[key]
+        else:
+            pos = await session.get(PositionModel, {"team_id": team_id, "symbol_id": symbol_id})
+            if pos is None:
+                pos = PositionModel(
+                    team_id=team_id,
+                    symbol_id=symbol_id,
+                    quantity=0,
+                    average_price=None,
+                    realized_pnl=0,
+                )
+                session.add(pos)
+                await session.flush()
+            if cache is not None:
+                cache[key] = pos
 
         qty_curr = pos.quantity
         avg = float(pos.average_price) if pos.average_price is not None else None
 
         if side == "buy":
             if qty_curr >= 0:
-                # increasing or opening long
                 if avg is None or qty_curr == 0:
                     pos.average_price = price
                 else:
                     pos.average_price = ((avg * qty_curr) + (price * qty)) / (qty_curr + qty)
                 pos.quantity = qty_curr + qty
             else:
-                # covering short
                 cover = min(qty, -qty_curr)
                 if avg is not None:
                     pos.realized_pnl = (float(pos.realized_pnl) + (avg - price) * cover)
@@ -256,20 +334,16 @@ class ExchangeManager:
                     pos.average_price = None
                 remaining = qty - cover
                 if remaining > 0:
-                    # establish long with remaining
                     pos.average_price = price
                     pos.quantity = remaining
         else:
-            # sell
             if qty_curr <= 0:
-                # increasing or opening short
                 if avg is None or qty_curr == 0:
                     pos.average_price = price
                 else:
                     pos.average_price = ((avg * (-qty_curr)) + (price * qty)) / ((-qty_curr) + qty)
                 pos.quantity = qty_curr - qty
             else:
-                # selling long
                 sell = min(qty, qty_curr)
                 if avg is not None:
                     pos.realized_pnl = (float(pos.realized_pnl) + (price - avg) * sell)
@@ -278,6 +352,5 @@ class ExchangeManager:
                     pos.average_price = None
                 remaining = qty - sell
                 if remaining > 0:
-                    # establish short with remaining
                     pos.average_price = price
                     pos.quantity = -remaining

--- a/backend/src/exchange/websocket_manager.py
+++ b/backend/src/exchange/websocket_manager.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from datetime import UTC
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import WebSocket
-from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from src.db.models import Order as OrderModel
-from src.db.models import Symbol as SymbolModel
 
 
 class WebSocketManager:
@@ -18,14 +13,11 @@ class WebSocketManager:
         self.connections: dict[WebSocket, dict[str, Any]] = {}
 
     def connect(self, websocket: WebSocket) -> None:
-        """Register a new WebSocket connection"""
-        self.connections[websocket] = {
-            "symbols": [],
-            "channels": []
-        }
+        """Register a new WebSocket connection."""
+        self.connections[websocket] = {"symbols": [], "channels": []}
 
     def disconnect(self, websocket: WebSocket) -> None:
-        """Remove a WebSocket connection"""
+        """Remove a WebSocket connection."""
         if websocket in self.connections:
             del self.connections[websocket]
 
@@ -33,138 +25,95 @@ class WebSocketManager:
         self,
         websocket: WebSocket,
         symbols: Sequence[str],
-        channels: Sequence[str]
+        channels: Sequence[str],
     ) -> None:
-        """Subscribe a connection to specific symbols and channels"""
+        """Subscribe a connection to specific symbols and channels."""
         if websocket in self.connections:
             self.connections[websocket]["symbols"] = list(symbols)
             self.connections[websocket]["channels"] = list(channels)
 
     def unsubscribe(self, websocket: WebSocket) -> None:
-        """Unsubscribe a connection from all channels"""
+        """Unsubscribe a connection from all channels."""
         if websocket in self.connections:
             self.connections[websocket]["symbols"] = []
             self.connections[websocket]["channels"] = []
 
     async def send_to_connection(self, websocket: WebSocket, data: dict[str, Any]) -> bool:
-        """Send data to a specific connection"""
+        """Send data to a specific connection."""
         try:
             await websocket.send_json(data)
             return True
-        except Exception as e:
-            print(f"Failed to send to WebSocket connection: {e}")
-            # Only disconnect if it's a connection error, not other errors
-            if "connection" in str(e).lower() or "closed" in str(e).lower():
+        except Exception as exc:  # pragma: no cover - network errors
+            print(f"Failed to send to WebSocket connection: {exc}")
+            if "connection" in str(exc).lower() or "closed" in str(exc).lower():
                 self.disconnect(websocket)
             return False
 
     async def broadcast_to_symbol(self, symbol: str, channel: str, data: dict[str, Any]) -> None:
-        """Broadcast data to all connections subscribed to a symbol and channel"""
-        disconnected = []
+        """Broadcast data to all connections subscribed to a symbol and channel."""
+        disconnected: list[WebSocket] = []
 
         for websocket, subscription in self.connections.items():
             if symbol in subscription["symbols"] and channel in subscription["channels"]:
                 try:
                     await websocket.send_json(data)
                 except Exception:
-                    # Connection is closed, mark for removal
                     disconnected.append(websocket)
 
-        # Remove disconnected connections
         for websocket in disconnected:
             self.disconnect(websocket)
 
-    async def get_order_book(self, symbol: str, session: AsyncSession) -> dict[str, Any]:
-        """Get real order book from database"""
-        # Get symbol_id
-        symbol_result = await session.scalar(
-            select(SymbolModel.id).where(SymbolModel.symbol == symbol)
-        )
-        if not symbol_result:
-            return {"bids": [], "asks": []}
-
-        # Get open buy orders (bids) - highest price first
-        bids_query = select(
-                        OrderModel.price,
-            func.sum(OrderModel.quantity - OrderModel.filled_quantity).label("total_quantity")
-        )\
-            .where(
-                OrderModel.symbol_id == symbol_result,
-                OrderModel.side == "buy",
-                OrderModel.status.in_(["pending", "partial"]),
-                OrderModel.price.is_not(None)
-            )\
-            .group_by(OrderModel.price)\
-            .order_by(OrderModel.price.desc())\
-            .limit(10)
-
-        bids_result = await session.execute(bids_query)
-        bids = [{"price": float(row.price), "quantity": int(row.total_quantity)}
-                for row in bids_result.fetchall()]
-
-        # Get open sell orders (asks) - lowest price first
-        asks_query = select(
-                        OrderModel.price,
-            func.sum(OrderModel.quantity - OrderModel.filled_quantity).label("total_quantity")
-        )\
-            .where(
-                OrderModel.symbol_id == symbol_result,
-                OrderModel.side == "sell",
-                OrderModel.status.in_(["pending", "partial"]),
-                OrderModel.price.is_not(None)
-            )\
-            .group_by(OrderModel.price)\
-            .order_by(OrderModel.price.asc())\
-            .limit(10)
-
-        asks_result = await session.execute(asks_query)
-        asks = [{"price": float(row.price), "quantity": int(row.total_quantity)}
-                for row in asks_result.fetchall()]
-
-        return {"bids": bids, "asks": asks}
-
-    async def notify_order_book_update(self, symbol: str, session: AsyncSession) -> None:
-        """Notify all subscribers of order book changes"""
-        from datetime import datetime
-
-        order_book = await self.get_order_book(symbol, session)
+    async def notify_order_book_update(
+        self,
+        symbol: str,
+        bids: Sequence[tuple[float, int]],
+        asks: Sequence[tuple[float, int]],
+    ) -> None:
+        """Notify subscribers of an updated order book snapshot."""
         timestamp = datetime.now(tz=UTC).isoformat()
+        bids_payload = [{"price": float(price), "quantity": int(quantity)} for price, quantity in bids]
+        asks_payload = [{"price": float(price), "quantity": int(quantity)} for price, quantity in asks]
 
-        # Send order book update
-        await self.broadcast_to_symbol(symbol, "orderbook", {
-            "type": "orderbook",
-            "symbol": symbol,
-            "bids": order_book["bids"],
-            "asks": order_book["asks"],
-            "timestamp": timestamp,
-        })
-
-        # Send quote update (best bid/ask)
-        bid = order_book["bids"][0]["price"] if order_book["bids"] else None
-        ask = order_book["asks"][0]["price"] if order_book["asks"] else None
-        bid_size = order_book["bids"][0]["quantity"] if order_book["bids"] else 0
-        ask_size = order_book["asks"][0]["quantity"] if order_book["asks"] else 0
-
-        if bid is not None or ask is not None:
-            await self.broadcast_to_symbol(symbol, "quotes", {
-                "type": "quote",
+        await self.broadcast_to_symbol(
+            symbol,
+            "orderbook",
+            {
+                "type": "orderbook",
                 "symbol": symbol,
-                "bid": bid,
-                "ask": ask,
-                "bid_size": bid_size,
-                "ask_size": ask_size,
+                "bids": bids_payload,
+                "asks": asks_payload,
                 "timestamp": timestamp,
-            })
+            },
+        )
+
+        if bids_payload or asks_payload:
+            await self.broadcast_to_symbol(
+                symbol,
+                "quotes",
+                {
+                    "type": "quote",
+                    "symbol": symbol,
+                    "bid": bids_payload[0]["price"] if bids_payload else None,
+                    "ask": asks_payload[0]["price"] if asks_payload else None,
+                    "bid_size": bids_payload[0]["quantity"] if bids_payload else 0,
+                    "ask_size": asks_payload[0]["quantity"] if asks_payload else 0,
+                    "timestamp": timestamp,
+                },
+            )
 
     async def notify_trade(self, symbol: str, price: float, quantity: int, timestamp: str) -> None:
-        """Notify all subscribers of a new trade"""
-        await self.broadcast_to_symbol(symbol, "trades", {
-            "type": "trade",
-            "symbol": symbol,
-            "price": price,
-            "quantity": quantity,
-            "timestamp": timestamp,
-        })
+        """Notify all subscribers of a new trade."""
+        await self.broadcast_to_symbol(
+            symbol,
+            "trades",
+            {
+                "type": "trade",
+                "symbol": symbol,
+                "price": price,
+                "quantity": quantity,
+                "timestamp": timestamp,
+            },
+        )
 
 
 # Global WebSocket manager instance

--- a/backend/tests/test_order_service.py
+++ b/backend/tests/test_order_service.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import asyncio
+
+from src.core.orders import OrderService
+from src.db import session as session_mod
+from src.db.models import Team
+
+
+def test_place_order_does_not_commit_session(test_app, monkeypatch) -> None:
+    async def _run() -> None:
+        async with session_mod.SessionLocal() as session:
+            team = Team(name="Team Perf", join_code="TPERF123")
+            session.add(team)
+            await session.commit()
+            await session.refresh(team)
+
+            service = OrderService(session)
+
+            async def _fail_commit() -> None:  # pragma: no cover - trigger if called
+                raise AssertionError("OrderService.place_order must not commit the session")
+
+            monkeypatch.setattr(session, "commit", _fail_commit)
+
+            order = await service.place_order(
+                team_id=team.id,
+                symbol_code="AAPL",
+                side="buy",
+                order_type="limit",
+                quantity=10,
+                price=101.0,
+            )
+
+            assert order.id is not None
+            assert order.status == "pending"
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- reuse cached order books during order placement and cancellation instead of replaying the full dataset
- tune the matching engine to insert/remove in order and short-circuit scans for better per-order latency
- streamline websocket notifications and add regression tests covering the new lifecycle guarantees

## Testing
- `uv run python -m pytest`
