### PR TITLE
feat: integrate liquibook-based matching engine

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "pytest-asyncio>=0.21.0",
   "google-auth>=2.35.0",
   "pytest-benchmark>=5.1.0",
+  "liquibook>=2.0.1",
 ]
 
 [tool.ruff]

--- a/backend/src/exchange/engine.py
+++ b/backend/src/exchange/engine.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+
+import liquibook
+
+PRICE_SCALE = 1_000_000
 
 
-@dataclass
+@dataclass(slots=True)
 class SimpleOrder:
     order_id: str
     side: str  # "buy" or "sell"
@@ -12,7 +19,7 @@ class SimpleOrder:
     team_id: str
 
 
-@dataclass
+@dataclass(slots=True)
 class SimpleTrade:
     buyer_order_id: str
     seller_order_id: str
@@ -20,166 +27,436 @@ class SimpleTrade:
     price: float
 
 
-@dataclass
+@dataclass(slots=True)
 class SimpleCancel:
     order_id: str
     quantity: int
     reason: str = "self_trade_prevention"
 
 
+@dataclass(slots=True)
+class _EventBuffer:
+    trades: list[SimpleTrade] = field(default_factory=list)
+    cancels: list[SimpleCancel] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class _OrderMeta:
+    simple: SimpleOrder
+    liquibook_order: liquibook.SimpleOrder
+    team_id: str
+    side: str
+    price_int: int
+    liquibook_id: int
+    open_qty: int
+    resting: bool = False
+    requeued: bool = False
+
+    @property
+    def order_id(self) -> str:
+        return self.simple.order_id
+
+
+class _SimpleOrderBook(liquibook.DepthOrderBook):  # type: ignore[misc]
+    def __init__(self, engine: "MatchingEngine") -> None:  # noqa: UP037
+        super().__init__()
+        self._engine = engine
+
+    def on_fill(
+        self,
+        order: liquibook.SimpleOrder,
+        matched_order: liquibook.SimpleOrder,
+        quantity: int,
+        price: int,
+        inbound_order_filled: bool,
+        matched_order_filled: bool,
+    ) -> None:
+        super().on_fill(
+            order,
+            matched_order,
+            quantity,
+            price,
+            inbound_order_filled,
+            matched_order_filled,
+        )
+        self._engine._handle_fill(order, matched_order, quantity, price)
+
+    def on_cancel(self, order: liquibook.SimpleOrder, quantity: int) -> None:
+        super().on_cancel(order, quantity)
+        self._engine._handle_cancel(order, quantity)
+
+    def on_replace(
+        self,
+        order: liquibook.SimpleOrder,
+        current_qty: int,
+        new_qty: int,
+        new_price: int,
+    ) -> None:
+        super().on_replace(order, current_qty, new_qty, new_price)
+        self._engine._handle_replace(order, current_qty, new_qty)
+
+    def on_order_book_change(self) -> None:
+        super().on_order_book_change()
+        self._engine._handle_book_change()
+
+
+def _price_to_int(price: float | None) -> int:
+    if price is None:
+        return 0
+    return round(price * PRICE_SCALE)
+
+
+def _price_to_float(price_int: int) -> float:
+    return price_int / PRICE_SCALE
+
+
+def _prices_cross(side: str, incoming: int, resting: int) -> bool:
+    if incoming == 0:
+        return True
+    if side == "buy":
+        return incoming >= resting
+    return incoming <= resting
+
+
+def _order_key(order: liquibook.SimpleOrder) -> int:
+    return int(order.order_id_)
+
+
 class MatchingEngine:
     def __init__(self) -> None:
-        self.bids: list[SimpleOrder] = []
-        self.asks: list[SimpleOrder] = []
+        self._book = _SimpleOrderBook(self)
+        self._active_buffer: _EventBuffer | None = None
+        self._orders_by_id: dict[str, _OrderMeta] = {}
+        self._orders_by_liquibook: dict[int, _OrderMeta] = {}
+        self._team_orders: dict[str, dict[str, set[str]]] = defaultdict(
+            lambda: {"buy": set(), "sell": set()}
+        )
+        self._suppress_cancel: set[str] = set()
 
     def reset(self) -> None:
-        """Clear all in-memory book state."""
-        self.bids.clear()
-        self.asks.clear()
-
-    def _insert_bid(self, order: SimpleOrder) -> None:
-        if order.price is None:
-            return
-        order_price = float(order.price)
-        idx = 0
-        while idx < len(self.bids):
-            existing_price = float(self.bids[idx].price or 0.0)
-            if existing_price >= order_price:
-                idx += 1
-            else:
-                break
-        self.bids.insert(idx, order)
-
-    def _insert_ask(self, order: SimpleOrder) -> None:
-        if order.price is None:
-            return
-        order_price = float(order.price)
-        idx = 0
-        while idx < len(self.asks):
-            existing_price = float(self.asks[idx].price or 0.0)
-            if existing_price <= order_price:
-                idx += 1
-            else:
-                break
-        self.asks.insert(idx, order)
+        self._book = _SimpleOrderBook(self)
+        self._active_buffer = None
+        self._orders_by_id.clear()
+        self._orders_by_liquibook.clear()
+        self._team_orders.clear()
+        self._suppress_cancel.clear()
 
     def add_resting_order(self, order: SimpleOrder) -> None:
-        """Insert a pre-existing limit order without attempting to match."""
-        if order.side == "buy":
-            self._insert_bid(order)
-        else:
-            self._insert_ask(order)
+        with self._collect_events():
+            self._enter_order(order)
 
     def add_order(self, order: SimpleOrder) -> tuple[list[SimpleTrade], list[SimpleCancel]]:
-        trades: list[SimpleTrade] = []
-        cancels: list[SimpleCancel] = []
-        if order.side == "buy":
-            trades, cancels = self._match_buy(order)
-            if order.quantity > 0 and order.price is not None:
-                self._insert_bid(order)
-        else:
-            trades, cancels = self._match_sell(order)
-            if order.quantity > 0 and order.price is not None:
-                self._insert_ask(order)
-        return trades, cancels
+        with self._collect_events() as buffer:
+            requeue = self._self_trade_prevent(order)
+            meta = self._enter_order(order)
+            re_add_inbound = False
+            inbound_remainder = meta.open_qty
+            if requeue and inbound_remainder > 0:
+                self._suppress_cancel.add(meta.order_id)
+                with self._collect_events():
+                    self._book.cancel(meta.liquibook_order)
+                re_add_inbound = True
+            elif order.price is None and inbound_remainder > 0:
+                self._suppress_cancel.add(meta.order_id)
+                with self._collect_events():
+                    self._book.cancel(meta.liquibook_order)
+                meta.open_qty = 0
+            if requeue:
+                self._requeue_orders(requeue)
+            if re_add_inbound and inbound_remainder > 0 and order.price is not None:
+                price_int = _price_to_int(order.price)
+                liquibook_order = liquibook.SimpleOrder(
+                    order.side == "buy",
+                    price_int,
+                    inbound_remainder,
+                    0,
+                    liquibook.oc_no_conditions,
+                )
+                meta.liquibook_order = liquibook_order
+                meta.liquibook_id = _order_key(liquibook_order)
+                meta.open_qty = inbound_remainder
+                meta.simple.quantity = inbound_remainder
+                meta.resting = True
+                self._orders_by_id[meta.order_id] = meta
+                self._orders_by_liquibook[meta.liquibook_id] = meta
+                self._register(meta)
+                self._book.add(liquibook_order)
+        return buffer.trades, buffer.cancels
 
     def get_orderbook_levels(
         self, depth: int = 10
     ) -> tuple[list[tuple[float, int]], list[tuple[float, int]]]:
-        bid_levels: dict[float, int] = {}
-        ask_levels: dict[float, int] = {}
-        for o in self.bids:
-            if o.price is None:
-                continue
-            bid_levels[o.price] = bid_levels.get(o.price, 0) + o.quantity
-        for o in self.asks:
-            if o.price is None:
-                continue
-            ask_levels[o.price] = ask_levels.get(o.price, 0) + o.quantity
-        bids_sorted = sorted(bid_levels.items(), key=lambda x: -x[0])[:depth]
-        asks_sorted = sorted(ask_levels.items(), key=lambda x: x[0])[:depth]
-        return bids_sorted, asks_sorted
+        book_depth = self._book.depth()
+        bids: list[tuple[float, int]] = []
+        for level in book_depth.get_bid_levels():
+            qty = level.aggregate_qty()
+            if qty > 0:
+                bids.append((_price_to_float(level.price()), qty))
+            if len(bids) >= depth:
+                break
+        asks: list[tuple[float, int]] = []
+        for level in book_depth.get_ask_levels():
+            qty = level.aggregate_qty()
+            if qty > 0:
+                asks.append((_price_to_float(level.price()), qty))
+            if len(asks) >= depth:
+                break
+        return bids, asks
 
     def remove_order(self, order_id: str) -> bool:
-        for book in (self.bids, self.asks):
-            for idx, existing in enumerate(book):
-                if existing.order_id == order_id:
-                    book.pop(idx)
-                    return True
-        return False
+        meta = self._orders_by_id.get(order_id)
+        if meta is None:
+            return False
+        with self._collect_events():
+            self._book.cancel(meta.liquibook_order)
+        return True
 
-    def _match_buy(self, buy: SimpleOrder) -> tuple[list[SimpleTrade], list[SimpleCancel]]:
-        trades: list[SimpleTrade] = []
-        cancels: list[SimpleCancel] = []
-        i = 0
-        while i < len(self.asks) and buy.quantity > 0:
-            ask = self.asks[i]
-            if ask.price is None:
-                i += 1
-                continue
-            if buy.price is not None and buy.price < ask.price:
-                break
-            if buy.price is None or buy.price >= ask.price:
-                if ask.team_id == buy.team_id:
-                    cancel_qty = min(buy.quantity, ask.quantity)
-                    if cancel_qty > 0:
-                        ask.quantity -= cancel_qty
-                        cancels.append(SimpleCancel(order_id=ask.order_id, quantity=cancel_qty))
-                        if ask.quantity == 0:
-                            self.asks.pop(i)
-                            continue
-                else:
-                    qty = min(buy.quantity, ask.quantity)
-                    trades.append(
-                        SimpleTrade(
-                            buyer_order_id=buy.order_id,
-                            seller_order_id=ask.order_id,
-                            quantity=qty,
-                            price=float(ask.price),
-                        )
-                    )
-                    buy.quantity -= qty
-                    ask.quantity -= qty
-                    if ask.quantity == 0:
-                        self.asks.pop(i)
-                        continue
-            i += 1
-        return trades, cancels
+    def _enter_order(self, order: SimpleOrder) -> _OrderMeta:
+        price_int = _price_to_int(order.price)
+        conditions = (
+            liquibook.oc_immediate_or_cancel if order.price is None else liquibook.oc_no_conditions
+        )
+        liquibook_order = liquibook.SimpleOrder(
+            order.side == "buy",
+            price_int,
+            order.quantity,
+            0,
+            conditions,
+        )
+        meta = _OrderMeta(
+            simple=order,
+            liquibook_order=liquibook_order,
+            team_id=order.team_id,
+            side=order.side,
+            price_int=price_int,
+            liquibook_id=_order_key(liquibook_order),
+            open_qty=order.quantity,
+        )
+        self._orders_by_id[order.order_id] = meta
+        self._orders_by_liquibook[_order_key(liquibook_order)] = meta
+        self._book.add(liquibook_order)
+        order.quantity = meta.open_qty
+        if order.price is not None and meta.open_qty > 0:
+            meta.resting = True
+            self._register(meta)
+        else:
+            if meta.open_qty == 0:
+                self._remove_meta(meta)
+        return meta
 
-    def _match_sell(self, sell: SimpleOrder) -> tuple[list[SimpleTrade], list[SimpleCancel]]:
-        trades: list[SimpleTrade] = []
-        cancels: list[SimpleCancel] = []
-        i = 0
-        while i < len(self.bids) and sell.quantity > 0:
-            bid = self.bids[i]
-            if bid.price is None:
-                i += 1
+    def _requeue_orders(self, requeue: list[tuple[_OrderMeta, int]]) -> None:
+        for meta, remainder in requeue:
+            if remainder <= 0:
                 continue
-            if sell.price is not None and sell.price > bid.price:
-                break
-            if sell.price is None or sell.price <= bid.price:
-                if bid.team_id == sell.team_id:
-                    cancel_qty = min(sell.quantity, bid.quantity)
-                    if cancel_qty > 0:
-                        bid.quantity -= cancel_qty
-                        cancels.append(SimpleCancel(order_id=bid.order_id, quantity=cancel_qty))
-                        if bid.quantity == 0:
-                            self.bids.pop(i)
-                            continue
-                else:
-                    qty = min(sell.quantity, bid.quantity)
-                    trades.append(
-                        SimpleTrade(
-                            buyer_order_id=bid.order_id,
-                            seller_order_id=sell.order_id,
-                            quantity=qty,
-                            price=float(bid.price),
-                        )
+            price_int = _price_to_int(meta.simple.price)
+            liquibook_order = liquibook.SimpleOrder(
+                meta.side == "buy",
+                price_int,
+                remainder,
+                0,
+                liquibook.oc_no_conditions,
+            )
+            meta.liquibook_order = liquibook_order
+            meta.liquibook_id = _order_key(liquibook_order)
+            meta.open_qty = remainder
+            meta.simple.quantity = remainder
+            meta.resting = True
+            meta.requeued = True
+            self._orders_by_id[meta.order_id] = meta
+            self._orders_by_liquibook[meta.liquibook_id] = meta
+            self._register(meta)
+            self._book.add(liquibook_order)
+
+    def _self_trade_prevent(self, incoming: SimpleOrder) -> list[tuple[_OrderMeta, int]]:
+        team_set = self._team_orders.get(incoming.team_id)
+        if not team_set:
+            return []
+        opposite_side = "sell" if incoming.side == "buy" else "buy"
+        candidates = list(team_set[opposite_side])
+        if not candidates:
+            return []
+        price_int = _price_to_int(incoming.price)
+        remaining_qty = incoming.quantity
+        requeue: list[tuple[_OrderMeta, int]] = []
+        for order_id in candidates:
+            meta = self._orders_by_id.get(order_id)
+            if not meta or not meta.resting:
+                continue
+            if not _prices_cross(incoming.side, price_int, meta.price_int):
+                continue
+            current_open = meta.open_qty
+            if current_open <= 0:
+                continue
+            cancel_qty = min(remaining_qty, current_open)
+            if cancel_qty <= 0:
+                continue
+            if cancel_qty >= current_open:
+                with self._collect_events():
+                    self._book.cancel(meta.liquibook_order)
+            else:
+                with self._collect_events():
+                    self._book.replace(
+                        meta.liquibook_order,
+                        -cancel_qty,
+                        meta.liquibook_order.price(),
                     )
-                    sell.quantity -= qty
-                    bid.quantity -= qty
-                    if bid.quantity == 0:
-                        self.bids.pop(i)
-                        continue
-            i += 1
-        return trades, cancels
+                remainder = current_open - cancel_qty
+                meta.open_qty = remainder
+                meta.simple.quantity = remainder
+                meta.resting = False
+                self._suppress_cancel.add(meta.order_id)
+                with self._collect_events():
+                    self._book.cancel(meta.liquibook_order)
+                requeue.append((meta, remainder))
+            remaining_qty -= cancel_qty
+            if remaining_qty <= 0:
+                break
+        return requeue
+
+    def _register(self, meta: _OrderMeta) -> None:
+        team_orders = self._team_orders[meta.team_id]
+        team_orders[meta.side].add(meta.order_id)
+
+    def _unregister(self, meta: _OrderMeta) -> None:
+        team_orders = self._team_orders.get(meta.team_id)
+        if not team_orders:
+            return
+        team_orders[meta.side].discard(meta.order_id)
+        if not team_orders["buy"] and not team_orders["sell"]:
+            self._team_orders.pop(meta.team_id, None)
+
+    def _remove_meta(self, meta: _OrderMeta) -> None:
+        self._orders_by_id.pop(meta.order_id, None)
+        self._orders_by_liquibook.pop(meta.liquibook_id, None)
+        if meta.resting:
+            self._unregister(meta)
+
+    def _lookup_meta(self, order: liquibook.SimpleOrder) -> _OrderMeta | None:
+        return self._orders_by_liquibook.get(_order_key(order))
+
+    def _handle_fill(
+        self,
+        order: liquibook.SimpleOrder,
+        matched_order: liquibook.SimpleOrder,
+        quantity: int,
+        price_int: int,
+    ) -> None:
+        buffer = self._active_buffer
+        if buffer is None:
+            return
+        inbound = self._lookup_meta(order)
+        resting = self._lookup_meta(matched_order)
+        if inbound is None or resting is None:
+            return
+        price = _price_to_float(price_int)
+        if inbound.team_id == resting.team_id:
+            self._handle_self_trade_fill(inbound, resting, quantity, price_int)
+            return
+        if inbound.side == "buy":
+            buyer_meta, seller_meta = inbound, resting
+        else:
+            buyer_meta, seller_meta = resting, inbound
+        buffer.trades.append(
+            SimpleTrade(
+                buyer_order_id=buyer_meta.order_id,
+                seller_order_id=seller_meta.order_id,
+                quantity=quantity,
+                price=price,
+            )
+        )
+        inbound.open_qty -= quantity
+        resting.open_qty -= quantity
+        inbound.simple.quantity = inbound.open_qty
+        resting.simple.quantity = resting.open_qty
+        if inbound.open_qty == 0:
+            if inbound.resting:
+                inbound.resting = False
+                self._unregister(inbound)
+            self._remove_meta(inbound)
+        if resting.open_qty == 0:
+            if resting.resting:
+                resting.resting = False
+                self._unregister(resting)
+            self._remove_meta(resting)
+
+    def _handle_cancel(self, order: liquibook.SimpleOrder, quantity: int) -> None:
+        buffer = self._active_buffer
+        meta = self._lookup_meta(order)
+        if meta is None:
+            return
+        meta.open_qty = 0
+        meta.simple.quantity = 0
+        if meta.resting:
+            meta.resting = False
+            self._unregister(meta)
+        self._remove_meta(meta)
+        if meta.order_id in self._suppress_cancel:
+            self._suppress_cancel.discard(meta.order_id)
+        elif buffer is not None and quantity > 0:
+            buffer.cancels.append(SimpleCancel(order_id=meta.order_id, quantity=quantity))
+
+    def _handle_replace(self, order: liquibook.SimpleOrder, current_qty: int, new_qty: int) -> None:
+        meta = self._lookup_meta(order)
+        if meta is None:
+            return
+        meta.open_qty = new_qty
+        meta.simple.quantity = new_qty
+        meta.price_int = order.price()
+        if meta.simple.price is not None:
+            meta.simple.price = _price_to_float(meta.price_int)
+        meta.resting = new_qty > 0 and meta.simple.price is not None
+        if meta.resting:
+            self._register(meta)
+        else:
+            self._unregister(meta)
+        cancel_qty = current_qty - new_qty
+        buffer = self._active_buffer
+        if buffer is not None and cancel_qty > 0:
+            buffer.cancels.append(SimpleCancel(order_id=meta.order_id, quantity=cancel_qty))
+
+    def _handle_book_change(self) -> None:
+        # Depth updates are pulled directly from the Liquibook depth tracker
+        # whenever they are requested, so no additional bookkeeping is needed.
+        return
+
+    def _handle_self_trade_fill(
+        self,
+        inbound_meta: _OrderMeta,
+        resting_meta: _OrderMeta,
+        quantity: int,
+        price_int: int,
+    ) -> None:
+        buffer = self._active_buffer
+        passive_meta = resting_meta if resting_meta.requeued else inbound_meta
+        active_meta = inbound_meta if passive_meta is resting_meta else resting_meta
+        if buffer is not None:
+            buffer.cancels.append(
+                SimpleCancel(order_id=passive_meta.order_id, quantity=quantity)
+            )
+        passive_meta.requeued = False
+        self._book.replace(
+            passive_meta.liquibook_order,
+            quantity,
+            passive_meta.liquibook_order.price(),
+        )
+        self._book.replace(
+            active_meta.liquibook_order,
+            quantity,
+            active_meta.liquibook_order.price(),
+        )
+        passive_meta.open_qty += quantity
+        active_meta.open_qty += quantity
+        passive_meta.simple.quantity = passive_meta.open_qty
+        active_meta.simple.quantity = active_meta.open_qty
+
+    @contextmanager
+    def _collect_events(self) -> Iterator[_EventBuffer]:
+        if self._active_buffer is not None:
+            yield self._active_buffer
+            return
+        buffer = _EventBuffer()
+        self._active_buffer = buffer
+        try:
+            yield buffer
+        finally:
+            self._active_buffer = None

--- a/backend/tests/performance/test_exchange_performance.py
+++ b/backend/tests/performance/test_exchange_performance.py
@@ -225,12 +225,13 @@ def test_matching_engine_limit_book_build_performance(
         total_time = sum(latencies) or 1e-9
         throughput = len(latencies) / total_time
 
+        bid_levels, ask_levels = engine.get_orderbook_levels(depth=100)
         return {
             "throughput_ops": throughput,
             "trades": float(trades),
             "traded_volume": float(traded_volume),
-            "remaining_bids": float(len(engine.bids)),
-            "remaining_asks": float(len(engine.asks)),
+            "remaining_bids": float(sum(qty for _, qty in bid_levels)),
+            "remaining_asks": float(sum(qty for _, qty in ask_levels)),
             "latency_series": latencies,
         }
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -242,6 +242,7 @@ dependencies = [
     { name = "greenlet" },
     { name = "httpx" },
     { name = "hypothesis" },
+    { name = "liquibook" },
     { name = "mypy" },
     { name = "orjson" },
     { name = "psycopg", extra = ["binary"] },
@@ -269,6 +270,7 @@ requires-dist = [
     { name = "greenlet", specifier = ">=3.0.3" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "hypothesis", specifier = ">=6.103.0" },
+    { name = "liquibook", specifier = ">=2.0.1" },
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "orjson", specifier = ">=3.10.3" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1.18" },
@@ -435,6 +437,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "liquibook"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/bf/f881c149456c275d7d80031434eb51ae4f6d096c4696c6d038985ba668d5/liquibook-2.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:360c049aaf9244e3379a6e000b7993b55e25363742b5e96a4f3b9acabffce58b", size = 178519, upload-time = "2025-09-06T18:31:31.202Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/60/14ec947339507db130adda46b11340163bae739d7ef72c31931dadfc1a6c/liquibook-2.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1ea884f0b7d8c67dbecaf979714f6f41a9b39913649a3ab605f59728ffa90a7", size = 228473, upload-time = "2025-09-06T18:31:32.323Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/6b/d253d3663b58e6ceae99a3e67896d796e939f133db577bcfc0bd91743e1d/liquibook-2.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95f48d8d4fe72ca2cf9556a1312555bc8bb03480738b3ce9331c72ea756710ef", size = 1264329, upload-time = "2025-09-06T18:31:33.245Z" },
+    { url = "https://files.pythonhosted.org/packages/60/54/eb73b87b91f0311e096d0c84de43f670a5d861591cfc456de0b960ea17ae/liquibook-2.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:f86661d132ab45f7299c9b0c08801598b785709ca2a2321473fa1f72405b4ea7", size = 206573, upload-time = "2025-09-06T18:31:34.319Z" },
+    { url = "https://files.pythonhosted.org/packages/82/9d/c17341a3a152d885bcdfa61c51c3f5f4c53f3627404264f40b1a52242901/liquibook-2.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:369750568b204a82e08cfb324582dd7fe0b08f299f1d542fd6cb76ca47bf0e45", size = 178560, upload-time = "2025-09-06T18:31:35.097Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2b/af231e2224e545011141ab2ce5c0dee157e1f9bc96a10339149fbdb4aea1/liquibook-2.0.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:623638ae6b31b46067b108ecfbc2bf5865b8d3d586bbbcb33ca6d98957468d3c", size = 228113, upload-time = "2025-09-06T18:31:36.618Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a2/fa5d1740f009ca9923e9a6d7df5cea580e03f9f2f595e5bab4d546b2153e/liquibook-2.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:55dea9e8b60a0687776b0a1475b213c6f2fdc893a1482b797d2e15d655c77ee4", size = 1263999, upload-time = "2025-09-06T18:31:37.884Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/18/51b1701b010255700e9b207ef72a6321b9a3354553360068a4615341fad2/liquibook-2.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e2a06680e55fd20b9244d160c555bf19a0ba2199f9be9482528090eda8826cbd", size = 206670, upload-time = "2025-09-06T18:31:38.832Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replace the in-memory Python matcher with a Liquibook-backed adapter that preserves self-trade prevention and market semantics
- update engine/property tests and benchmark reporting to cover the new behavior
- pull in the Liquibook Python wrapper dependency for production use

## Testing
- uv run ruff check
- uv run python -m mypy src
- uv run python -m pytest
